### PR TITLE
Exception handled #1

### DIFF
--- a/image_to_numpy/src.py
+++ b/image_to_numpy/src.py
@@ -81,7 +81,18 @@ def load_image_file(file, mode='RGB'):
 
     if hasattr(PIL.ImageOps, 'exif_transpose'):
         # Very recent versions of PIL can do exit transpose internally
-        img = PIL.ImageOps.exif_transpose(img)
+        
+        # PIL.ImageOps.exif_transpose() is raising an exception.
+        # perform exif_transpose() manually until it gets fixed.
+        try:
+
+            img = PIL.ImageOps.exif_transpose(img)
+
+        except:
+            
+            img = PIL.Image.open(file)
+            img = exif_transpose(img)
+
     else:
         # Otherwise, do the exif transpose ourselves
         img = exif_transpose(img)


### PR DESCRIPTION
PIL.ImageOps.exif_transpose() is raising exception. it is mentioned in #1 . Until it is fixed, the user-defined function is used in exception block.
`PIL.ImageOps.exif_transpose()` in `try` block is erasing the orientation parameter of the image internally before raising exception. So a new instance of the image is created in the `exception` block to get the orientation parameter and transpose is performed with the user-defined function.